### PR TITLE
🧙‍♀️ magical identification of data sources

### DIFF
--- a/main/helpers.py
+++ b/main/helpers.py
@@ -2,6 +2,7 @@ import requests
 from django.conf import settings
 from django.urls import reverse
 from main.models import SharedNotebook
+import re
 
 
 def get_notebook_files(oh_member_data):
@@ -53,3 +54,16 @@ def find_notebook_by_keywords(search_term, search_field=None):
 
     nbs = notebooks_tag | notebooks_source | notebooks_description | notebooks_name | notebooks_user
     return nbs
+
+
+def suggest_data_sources(notebook_content):
+    print(notebook_content)
+    potential_sources = re.findall("direct-sharing-\d+", str(notebook_content))
+    if potential_sources:
+        response = requests.get(
+            'https://www.openhumans.org/api/public-data/members-by-source/')
+        source_names = {i['source']: i['name'] for i in response.json()}
+        suggested_sources = [source_names[i] for i in potential_sources
+                          if i in source_names]
+        return ",".join(suggested_sources)
+    return ""

--- a/main/helpers.py
+++ b/main/helpers.py
@@ -26,7 +26,7 @@ def create_notebook_link(notebook, request):
     base_url = request.build_absolute_uri("/").rstrip('/')
     jupyterhub_url = settings.JUPYTERHUB_BASE_URL
     export_url = reverse('export-notebook', args=(notebook.id,))
-    notebook_link = '{}/gallery-import?notebook_location={}{}&notebook_name={}'.format(
+    notebook_link = '{}/notebook-import?notebook_location={}{}&notebook_name={}'.format(
         jupyterhub_url,
         base_url,
         export_url,

--- a/main/templates/main/add_notebook.html
+++ b/main/templates/main/add_notebook.html
@@ -34,6 +34,12 @@
         value="{{data_sources}}"
         placeholder="Enter a comma-separated list of data sources your notebook uses" required>
       <p class="help-block">
+        {%if not edit%}
+        <b>
+          We have tried to extract the names of all <i>Open Humans</i> data sources we found in your notebook.
+          Please check whether these are correct.
+        </b>
+        {%endif%}
       Please specify the data sources your notebook uses. This makes it easier for people to find notebooks relevant for them.
       </p>
     </div>

--- a/main/views.py
+++ b/main/views.py
@@ -10,6 +10,7 @@ from open_humans.models import OpenHumansMember
 from ohapi import api
 from .helpers import get_notebook_files, get_notebook_oh, download_notebook_oh
 from .helpers import create_notebook_link, find_notebook_by_keywords
+from .helpers import suggest_data_sources
 from .models import SharedNotebook, NotebookLike
 from django.http import HttpResponse
 from django.urls import reverse
@@ -159,11 +160,13 @@ def add_notebook(request, notebook_id):
                        'notebook_id': str(notebook_id),
                        'edit': True}
         else:
+            notebook_content = download_notebook_oh(notebook_url)
+            suggested_sources = suggest_data_sources(notebook_content)
             context = {'description': '',
                        'name': notebook_name,
                        'notebook_id': str(notebook_id),
                        'tags': '',
-                       'data_sources': ''}
+                       'data_sources': suggested_sources}
         return render(request, 'main/add_notebook.html', context=context)
 
 


### PR DESCRIPTION
Closes #6 

The `add_notebook` `view` now tries to automagically extract the data sources found in a given notebook (magic thanks to `re.findall`). 

If the extraction of the `direct-sharing-\d` yields any data sources a call to the OH public data API is made to generate a translation table from direct-sharing-ID to human readable name and the `add_notebook.html` will be filled with these names for the `data source form`. 

If no sources are found (or we just want to overwrite an existing notebook) the tags aren't extracted again, as we don't want to mess with the data already entered by a user. 

